### PR TITLE
Export `TokenKind` as enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ wasm-bindgen = {version="0.2", features=["serde-serialize"]}
 js-sys = "0.3.38"
 serde = {version="1.0.106", features=["derive"]}
 combine = "4.0.0-beta.1"
-edgeql-parser = {git = "https://github.com/edgedb/edgedb"}
 console_error_panic_hook = { version = "0.1.1", optional = true }
 wee_alloc = { version = "0.4.2", optional = true }
+
+[dependencies.edgeql-parser]
+features=["wasm-lexer"]
+git = "https://github.com/edgedb/edgedb"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Token {
-    pub kind: String,
+    pub kind: edgeql_parser::tokenizer::Kind,
     pub value: String,
     pub position: Position,
 }
@@ -29,7 +29,6 @@ pub struct Position {
 #[wasm_bindgen(module="error")]
 extern "C" {
     pub type TokenizerError;
-
     #[wasm_bindgen(constructor)]
     fn new(message: String, position: Position) -> TokenizerError;
 }
@@ -55,7 +54,7 @@ pub fn lex_edgeql(input: &str) -> Result<Vec<Token>, TokenizerError> {
         match res {
             Ok(t) => {
                 tokens.push(Token {
-                    kind: format!("{:?}", t.token.kind),
+                    kind: t.token.kind,
                     value: t.token.value.into(),
                     position: Position {
                         line: pos.line,


### PR DESCRIPTION
This makes automatic import of token kind enum. Improves upon #2, but doesn't contain that fully.

Requires: https://github.com/edgedb/edgedb/pull/1754
And then `cargo update -p edgeql-parser`.