### PR TITLE
Add build step to extract generated TokenKind enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 pkg/
 wasm-pack.log
 /node_modules
+src/tokens.ts

--- a/extractTokens.js
+++ b/extractTokens.js
@@ -1,0 +1,9 @@
+const tokens = require("./temp/edgeql_wasm.js").TokenKind;
+
+console.log(`export enum TokenKind {`);
+
+Object.values(tokens)
+  .filter((token) => typeof token === "string")
+  .forEach((token) => console.log(`  ${token} = "${token}",`));
+
+console.log(`}`);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "/loader"
   ],
   "scripts": {
-    "build": "cargo build && wasm-pack build && sed -i -e \"s/from 'error'/from '.\\/error'/g\" pkg/edgeql_wasm_bg.js && tsc"
+    "extractTokens": "wasm-pack build --out-dir temp --target nodejs && sed -i -e \"s/require(String.raw\\`error\\`)/require(String.raw\\`.\\/error\\`)/\" temp/edgeql_wasm.js && tsc --outDir temp && node extractTokens > src/tokens.ts && rm -r temp",
+    "build": "cargo build && wasm-pack build && sed -i -e \"s/from 'error'/from '.\\/error'/g\" pkg/edgeql_wasm_bg.js && yarn run extractTokens && tsc"
   },
   "devDependencies": {
     "typescript": "^3.8.3"

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,4 @@
-interface Position {
+export interface Position {
   line: number;
   column: number;
   offset: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
-export {TokenizerError} from './error'
+import {TokenizerError, Position} from "./error";
+import {loadLib} from "../loader";
 
-import {loadLib} from "../loader"
+// @ts-ignore
+import {TokenKind} from "./tokens";
 
-export async function lexEdgeQL(str: string): Promise<any> {
+export {TokenizerError, TokenKind};
+
+export interface Token {
+  kind: TokenKind;
+  value: string;
+  position: Position;
+}
+
+export async function lexEdgeQL(str: string): Promise<Token[]> {
   const lib = await loadLib();
   return lib.lexEdgeQL(str);
 }


### PR DESCRIPTION
This adds a build step that creates a temp build targeting node.js, imports the `TokenKind` enum from it, then generates a new .ts file in src containing the enum, to be imported/exported by index.ts. It's a little bit convoluted, but does automatically generate the correct types in the end.